### PR TITLE
Updated to work with Django 1.7, with some refinements.

### DIFF
--- a/djangobwr/finders.py
+++ b/djangobwr/finders.py
@@ -1,8 +1,6 @@
 from django.contrib.staticfiles.finders import AppDirectoriesFinder
-from django.contrib.staticfiles.storage import AppStaticStorage
 
 class AppDirectoriesFinderBower(AppDirectoriesFinder):
-    storage_class = AppStaticStorage
 
     def list(self, ignore_patterns):
         """

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -37,13 +37,14 @@ class Command(BaseCommand):
     """
     help = textwrap.dedent(__doc__).lstrip()
     component_root = getattr(settings, 'COMPONENT_ROOT', os.path.join(settings.STATIC_ROOT, "components"))
-    option_list = BaseCommand.option_list + (
-        make_option('--with-version', dest='with_version', default=False, action='store_true',
-            help='Create component directories with version numbers'),
-        make_option('--keep-packages', dest='keep_packages', default=False, action='store_true',
+
+    def add_arguments(self, parser):
+        parser.add_argument('--with-version', dest='with_version', default=False, action='store_true',
+            help='Create component directories with version numbers')
+        parser.add_argument('--keep-packages', dest='keep_packages', default=False, action='store_true',
             help='Keep the downloaded bower packages, instead of removing them after moving '
-                'distribution files to settings.COMPONENT_ROOT'),
-    )
+                'distribution files to settings.COMPONENT_ROOT')
+
     bower_info = {}
     overrides = {}
 

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -142,12 +142,6 @@ class Command(BaseCommand):
                         src_pattern = os.path.join(src_root, pattern)
                         # main_list elements can be fileglob patterns
                         for src_path in glob.glob(src_pattern):
-                            # See if we have a minified alternative
-                            path, ext = os.path.splitext(src_path)
-                            min_path = path+".min"+ext
-                            if os.path.exists(min_path):
-                                src_path = min_path
-
                             if not os.path.exists(src_path):
                                 print("Could not find source path: %s" % (src_path, ))
 

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -3,7 +3,10 @@ import sys
 import json
 import tempfile
 import shutil
+import hashlib
+import glob
 from subprocess import call
+from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -19,6 +22,12 @@ class Command(BaseCommand):
         - Gruntfile.js: grunt default
         - bower.json: bower install
     """
+    option_list = BaseCommand.option_list + (
+        make_option('--with-version', dest='with_version', default=False, action='store_true',
+            help='Create component directories with version numbers'),
+    )
+    bower_info = {}
+
     def npm_install(self, pkg_json_path):
         os.chdir(os.path.dirname(pkg_json_path))
         call(['npm', 'install'])
@@ -40,11 +49,16 @@ class Command(BaseCommand):
         # run bower command
         call(args)
 
+    def get_bower_info(self, bower_json_path):
+        if not bower_json_path in self.bower_info:
+            self.bower_info[bower_json_path] = json.load(open(bower_json_path))
+
     def get_bower_main_list(self, bower_json_path):
         """Returns the bower.json main list or empty list.
         """
+        self.get_bower_info(bower_json_path)
 
-        main_list = json.load(open(bower_json_path)).get('main')
+        main_list = self.bower_info[bower_json_path].get('main')
 
         if isinstance(main_list, list):
             return main_list
@@ -54,24 +68,75 @@ class Command(BaseCommand):
 
         return []
 
+    def get_bower_version(self, bower_json_path):
+        """Returns the bower.json main list or empty list.
+        """
+        self.get_bower_info(bower_json_path)
+
+        return self.bower_info[bower_json_path].get("version")
+
     def clean_components_to_static_dir(self, bower_dir):
 
+        component_root = getattr(settings, 'COMPONENT_ROOT', os.path.join(settings.STATIC_ROOT, "components"))
+
         for directory in os.listdir(bower_dir):
+            print("Copying files from %s" % (directory, ))
 
-            # ensures dest dir
-            static_root = os.path.join(settings.STATIC_ROOT, directory)
-            if not os.path.exists(static_root):
-                os.makedirs(static_root)
+            src_root = os.path.join(bower_dir, directory)
 
-            bower_json_path = os.path.join(bower_dir, directory, 'bower.json')
-            main_list = self.get_bower_main_list(bower_json_path)
+            for bower_json in ['bower.json', '.bower.json']:
+                bower_json_path = os.path.join(src_root, bower_json)
+                if os.path.exists(bower_json_path):
+                    main_list = self.get_bower_main_list(bower_json_path)
+                    version   = self.get_bower_version(bower_json_path)
 
-            for path in filter(None, main_list):
-                tmp_path = os.path.join(bower_dir, directory, path)
-                print('{0} > {1}'.format(tmp_path, static_root))
-                shutil.copy(tmp_path, static_root)
+                    dst_root = os.path.join(component_root, directory)
+                    if self.with_version:
+                        assert not dst_root.endswith(os.sep)
+                        dst_root += "-"+version
+
+                    for pattern in filter(None, main_list):
+                        src_pattern = os.path.join(src_root, pattern)
+                        # main_list elements can be fileglob patterns
+                        for src_path in glob.glob(src_pattern):
+                            # See if we have a minified alternative
+                            path, ext = os.path.splitext(src_path)
+                            min_path = path+".min"+ext
+                            if os.path.exists(min_path):
+                                src_path = min_path
+
+                            if not os.path.exists(src_path):
+                                print("Could not find source path: %s" % (src_path, ))
+
+                            # Build the destination path
+                            base = os.path.basename(src_path)
+                            dst_path = os.path.join(dst_root, base)
+
+                            # Normalize the paths, for good looks
+                            src_path = os.path.abspath(src_path)
+                            dst_path = os.path.abspath(dst_path)
+
+                            # Check if we need to copy the file at all.
+                            if os.path.exists(dst_path):
+                                with open(src_path) as src:
+                                    src_hash = hashlib.sha1(src.read()).hexdigest()
+                                with open(dst_path) as dst:
+                                    dst_hash = hashlib.sha1(dst.read()).hexdigest()
+                                if src_hash == dst_hash:
+                                    #print('{0} = {1}'.format(src_path, dst_path))
+                                    continue
+
+                            # Make sure dest dir exists.
+                            if not os.path.exists(dst_root):
+                                os.makedirs(dst_root)
+
+                            print('{0} > {1}'.format(src_path, dst_root))
+                            shutil.copy(src_path, dst_root)
+                    break
 
     def handle(self, *args, **options):
+
+        self.with_version = options.get("with_version")
 
         npm_list = []
         grunt_list = []
@@ -105,11 +170,11 @@ class Command(BaseCommand):
         for path in bower_list:
             self.bower_install(path, temp_dir)
 
-        bower_dir = os.path.join(temp_dir, 'static', 'bower_components')
+        bower_dir = os.path.join(temp_dir, 'bower_components')
 
         # nothing to clean
         if not os.path.exists(bower_dir):
-            print('no app found bower.json file to build')
+            print('No components seems to have been installed by bower, exiting.')
             sys.exit(0)
 
         self.clean_components_to_static_dir(bower_dir)

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -9,6 +9,8 @@ import textwrap
 from subprocess import call, check_output, CalledProcessError
 from optparse import make_option
 
+import debug                            # pyflakes:ignore
+
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.contrib.staticfiles import finders
@@ -60,14 +62,16 @@ class Command(BaseCommand):
         # case that it's not installed.  Do this separately from the 'bower install' call, in
         # order not to warn about a missing bower in the case of installation-related errors.
         try:
-            bower_version = check_output(['bower', '--version'])
+            bower_version = check_output(['bower', '--version']).strip()
         except OSError as e:
             print("Trying to run bower failed -- is it installed?  The error was: %s" % e)
             exit(1)
         except CalledProcessError as e:
             print("Checking the bower version failed: %s" % e)
             exit(2)
-        print("Bower %s" % bower_version)
+
+        print("\nBower %s" % bower_version)
+        print("Installing from %s\n" % bower_json_path)
 
         # bower args
         args = ['bower', 'install', bower_json_path,

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -98,8 +98,11 @@ class Command(BaseCommand):
         main_list = self.bower_info[bower_json_path].get('main')
         component = self.bower_info[bower_json_path].get('name')
 
-        if self.bower_info[override].get("overrides").get(component):
-            main_list = self.bower_info[override].get("overrides").get(component).get("main")
+        if (override in self.bower_info
+            and "overrides" in self.bower_info[override] 
+            and component in self.bower_info[override].get("overrides")
+            and "main" in self.bower_info[override].get("overrides").get(component)):
+                main_list = self.bower_info[override].get("overrides").get(component).get("main")
 
         if isinstance(main_list, list):
             return main_list

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -130,7 +130,7 @@ class Command(BaseCommand):
             for bower_json in ['bower.json', '.bower.json']:
                 bower_json_path = os.path.join(src_root, bower_json)
                 if os.path.exists(bower_json_path):
-                    main_list = self.get_bower_main_list(bower_json_path, override)
+                    main_list = self.get_bower_main_list(bower_json_path, override) + ['bower.json']
                     version   = self.get_bower_version(bower_json_path)
 
                     dst_root = os.path.join(self.component_root, directory)

--- a/djangobwr/management/commands/bower_install.py
+++ b/djangobwr/management/commands/bower_install.py
@@ -182,7 +182,7 @@ class Command(BaseCommand):
         self.with_version = options.get("with_version")
         self.keep_packages = options.get("keep_packages")
 
-        temp_dir = getattr(settings, 'BWR_APP_TMP_FOLDER', '.tmp')
+        temp_dir = getattr(settings, 'BWR_APP_TMP_FOLDER', 'tmp')
         temp_dir = os.path.abspath(temp_dir)
 
         # finders


### PR DESCRIPTION
Updated the finder to work with Django 1.7. 

Added a switch --with-version to place components in directories named with version strings, which can be an advantage for component upgrades when deploying static via a CDN with long cache times.

Added support for file-glob patterns in the bower master list. Added support for picking minified versions over regular versions if they are available in the bower dir.

Added a check for bower availability, in order to give a better error message if it's not.
